### PR TITLE
Fix up Haddock comments

### DIFF
--- a/FormalLanguage/CFG/Grammar.hs
+++ b/FormalLanguage/CFG/Grammar.hs
@@ -68,12 +68,17 @@ instance Default Enumerable where
 -- TODO write Eq,Ord by hand. Fail with error if Enumerable is not equal (this
 -- should actually be caught in the combination operations).
 
+-- | 'T' – A terminal symbol (excluding epsilon)
+--
+-- 'N' – A non-terminal symbol (again, excluding non-terminal epsilons)
+--
+-- 'E' – Epsilon characters, may be named differently
 data TN where
-  -- | A terminal symbol (excluding epsilon)
+
   T :: String               -> TN
-  -- | A non-terminal symbol (again, excluding non-terminal epsilons)
+
   N :: String -> Enumerable -> TN
-  -- | Epsilon characters, may be named differently
+
   E ::                         TN
 
 deriving instance Show TN


### PR DESCRIPTION
Documenting GADT constructors this way is not supported in Haddock. See [this ticket](http://trac.haskell.org/haddock/ticket/43). The best one can do is to use GADT records and comment the fields.

Due to this, Hackage documentation wasn't being built. See [this build log](http://hackage.haskell.org/package/FormalGrammars-0.0.0.2/reports/1/log) for details.

I worked around the issue by documenting the constructors in the data declaration comment instead.

It now looks like this:
![GADT constructor documentation](http://fuuzetsu.co.uk/images/1388921814.png)
